### PR TITLE
Sortable keywords

### DIFF
--- a/lib/phoenix_datatables/query.ex
+++ b/lib/phoenix_datatables/query.ex
@@ -76,7 +76,7 @@ defmodule PhoenixDatatables.Query do
           else
             _ -> raise ArgumentError, "#{column_name} is not a sortable column."
           end
-        order when is_number(order) -> {parent, order}
+        order when is_number(order) -> {String.to_atom(parent), order}
       end
     else
       raise ArgumentError, "#{column_name} is not a sortable column."

--- a/test/phoenix_datatables/query_test.exs
+++ b/test/phoenix_datatables/query_test.exs
@@ -47,20 +47,24 @@ defmodule PhoenixDatatables.QueryTest do
     test "appends order-by clause to a join query specifying sortable fields & orders" do
       [item1, item2] = add_items()
 
-      request = %{Factory.raw_request | "order" => %{"0" => %{"column" => "7", "dir" => "asc"}}}
       query =
       (from item in Item,
         join: category in assoc(item, :category),
         select: %{id: item.id, category_name: category.name})
 
-      query =
-        request
-        |> Request.receive
-        |> Query.sort(query, @sortable_join)
+      do_test = fn request ->
+        query =
+          request
+          |> Request.receive
+          |> Query.sort(query, @sortable_join)
 
-      [ritem2, ritem1] = query |> Repo.all
-      assert item1.id == ritem1.id
-      assert item2.id == ritem2.id
+        [ritem2, ritem1] = query |> Repo.all
+        assert item1.id == ritem1.id
+        assert item2.id == ritem2.id
+      end
+
+      do_test.(Factory.raw_request)
+      do_test.(%{Factory.raw_request | "order" => %{"0" => %{"column" => "7", "dir" => "asc"}}})
     end
 
     test "appends order-by clause to a joined table" do


### PR DESCRIPTION
`cast_column` is maybe getting too hairy. The idea is you should be able to pass a list of keywords that specify the columns that are eligible for sort - we may need something similar for search as well, to make it possible to exclude columns used in search - e.g. to only use indexed columns. 

If the columns are in the base table, you really just need a list of those atoms - so that's the simpler syntax / overload that uses the 4-line clause of `cast_column`:

```Elixir
  @sortable [:nsn, :common_name]
```

But if a column you want to order by is in an association, you need to tell me the name of that association and the column name. And if you're using this more complicated version, we'll go ahead and demand the join_order as well - this will make it possible to use this on queries that have joins of subqueries, which we will need ourselves for the activity index.

So then your `sortable` arg looks this - we need `cast_column` to tell us safely whether those keys are in the association, and if so then return to us the specified column name and the join order.
```Elixir
  @sortable_join [nsn: 0, category: [name: 1]]
```