### PR TITLE
Name attribute for server column

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,68 @@ $(document).ready(() => {
 };
 ```
 
+## Joins
+
+Ecto queryables using joins are supported with automatic introspection - meaning columns used in the DataTable will be sortable and searchable if they are specified appropriately in the client-side configuration. The `example/` project in the source repo works this way.
+
+Assuming an Ecto queryable that looks like:
+
+```elixir
+    query =
+      from item in Item,
+      join: category in assoc(item, :category),
+      join: unit in assoc(item, :unit),
+      preload: [category: category, unit: unit]
+```
+
+And a view transformation that looks like: 
+
+```elixir
+  def item_json(item) do
+    %{
+      nsn: item.nsn,
+      rep_office: item.rep_office,
+      common_name: item.common_name,
+      description: item.description,
+      price: item.price,
+      ui: item.ui,
+      aac: item.aac,
+      unit_description: item.unit.description,
+      category_name: item.category.name,
+    }
+  end
+```
+
+Could be used with a client-side configuration that looks like:
+```javascript
+      columns: [
+        { data: "nsn" },
+        { data: "category_name", name: "category.name"},
+        { data: "common_name" },
+        { data: "description" },
+        { data: "price" },
+        { data: "unit_description", name: "unit.description" },
+        { data: "aac" },
+      ]
+    });
+```
+
+You'll notice this differs from the basic configuration in that a `name` attribute is specified with the qualified column name. You could alternatively use the value `unit.description` in the `data` attribute and not supply a name attribute, but then the DataTables client library will expect to find a nested structure in the response message, so your view would have to nest it e.g.: 
+
+```javascript
+ columns: [
+        { data: "nsn" },
+        { data: "category_name", name: "category.name"},
+        { data: "common_name" },
+        { data: "description" },
+        { data: "price" },
+        unit: %{
+          description: item.unit.description
+        },
+```
+
+The important thing to understand is that when a `name` attribute is supplied, the server uses that to identify the field to search / sort - regardless of the value of the `data` attribute. The *client* library always uses `data` to identify the data path to map the response into the generated HTML. The client uses the `name` attribute only to make it easier to refer to columns by name in scripts using the client API.
+
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -259,20 +259,27 @@ Could be used with a client-side configuration that looks like:
 
 You'll notice this differs from the basic configuration in that a `name` attribute is specified with the qualified column name. You could alternatively use the value `unit.description` in the `data` attribute and not supply a name attribute, but then the DataTables client library will expect to find a nested structure in the response message, so your view would have to nest it e.g.: 
 
-```javascript
- columns: [
-        { data: "nsn" },
-        { data: "category_name", name: "category.name"},
-        { data: "common_name" },
-        { data: "description" },
-        { data: "price" },
-        unit: %{
-          description: item.unit.description
-        },
+```elixir
+  def item_json(item) do
+    %{
+      nsn: item.nsn,
+      rep_office: item.rep_office,
+      common_name: item.common_name,
+      description: item.description,
+      price: item.price,
+      ui: item.ui,
+      aac: item.aac,
+      unit: %{
+        description: item.unit.description
+      },
+      category: %{
+        name: item.category.name
+      },
+    }
+  end
 ```
 
 The important thing to understand is that when a `name` attribute is supplied, the server uses that to identify the field to search / sort - regardless of the value of the `data` attribute. The *client* library always uses `data` to identify the data path to map the response into the generated HTML. The client uses the `name` attribute only to make it easier to refer to columns by name in scripts using the client API.
-
 
 ## Credits
 

--- a/example/assets/js/table.js
+++ b/example/assets/js/table.js
@@ -11,7 +11,7 @@ export default function() {
     $('[data-datatable-server]').dataTable({
       lengthChange: false,
       serverSide: true,
-      ajax: 'api/items',
+      ajax: 'datatables/items',
       columns: [
         { data: "nsn" },
         { data: "rep_office" },

--- a/example/assets/js/table.js
+++ b/example/assets/js/table.js
@@ -11,11 +11,11 @@ export default function() {
       ajax: 'datatables/items',
       columns: [
         { data: "nsn" },
-        { data: "category.name" },
+        { data: "category_name", name: "category.name"},
         { data: "common_name" },
         { data: "description" },
         { data: "price" },
-        { data: "unit.description" },
+        { data: "unit_description", name: "unit.description" },
         { data: "aac" },
       ]
     });

--- a/example/assets/js/table.js
+++ b/example/assets/js/table.js
@@ -4,9 +4,6 @@ import dt from 'datatables.net';
 export default function() {
   $(document).ready(() => {
     dt();
-    $('[data-datatable]').dataTable({
-      lengthChange: false,
-    });
 
     $('[data-datatable-server]').dataTable({
       lengthChange: false,
@@ -14,12 +11,12 @@ export default function() {
       ajax: 'datatables/items',
       columns: [
         { data: "nsn" },
-        { data: "rep_office" },
+        { data: "category.name" },
         { data: "common_name" },
         { data: "description" },
         { data: "price" },
-        { data: "ui" },
-        { data: "aac" }
+        { data: "unit.description" },
+        { data: "aac" },
       ]
     });
   })

--- a/example/lib/phoenix_datatables_example/stock/stock.ex
+++ b/example/lib/phoenix_datatables_example/stock/stock.ex
@@ -8,7 +8,12 @@ defmodule PhoenixDatatablesExample.Stock do
   alias PhoenixDatatablesExample.Stock.Item
 
   def datatable_items(params) do
-    Repo.fetch_datatable(Item, params)
+    query =
+      from item in Item,
+      join: category in assoc(item, :category),
+      join: unit in assoc(item, :unit),
+      preload: [category: category, unit: unit]
+    Repo.fetch_datatable(query, params)
   end
 
   @doc """

--- a/example/lib/phoenix_datatables_example_web/controllers/item_table_controller.ex
+++ b/example/lib/phoenix_datatables_example_web/controllers/item_table_controller.ex
@@ -5,6 +5,6 @@ defmodule PhoenixDatatablesExampleWeb.ItemTableController do
   action_fallback PhoenixDatatablesExampleWeb.FallbackController
 
   def index(conn, params) do
-    render(conn, :index, payload: Stock.datatable_items(params))
+    render(conn, "index.json", payload: Stock.datatable_items(params))
   end
 end

--- a/example/lib/phoenix_datatables_example_web/router.ex
+++ b/example/lib/phoenix_datatables_example_web/router.ex
@@ -2,7 +2,7 @@ defmodule PhoenixDatatablesExampleWeb.Router do
   use PhoenixDatatablesExampleWeb, :router
 
   pipeline :browser do
-    plug :accepts, ["html"]
+    plug :accepts, ["html", "json"]
     plug :fetch_session
     plug :fetch_flash
     plug :protect_from_forgery
@@ -20,8 +20,8 @@ defmodule PhoenixDatatablesExampleWeb.Router do
     resources "/items", ItemController
   end
 
-  scope "/api", PhoenixDatatablesExampleWeb do
-    pipe_through :api
+  scope "/datatables", PhoenixDatatablesExampleWeb do
+    pipe_through :browser
 
     get "/items", ItemTableController, :index
   end

--- a/example/lib/phoenix_datatables_example_web/templates/item/index.html.eex
+++ b/example/lib/phoenix_datatables_example_web/templates/item/index.html.eex
@@ -10,7 +10,6 @@
       <th>Price</th>
       <th>Ui</th>
       <th>Aac</th>
-      <th>Unit Description</th>
     </tr>
   </thead>
 </table>

--- a/example/lib/phoenix_datatables_example_web/templates/item/index.html.eex
+++ b/example/lib/phoenix_datatables_example_web/templates/item/index.html.eex
@@ -10,6 +10,7 @@
       <th>Price</th>
       <th>Ui</th>
       <th>Aac</th>
+      <th>Unit Description</th>
     </tr>
   </thead>
 </table>

--- a/example/lib/phoenix_datatables_example_web/views/item_table_view.ex
+++ b/example/lib/phoenix_datatables_example_web/views/item_table_view.ex
@@ -13,7 +13,13 @@ defmodule PhoenixDatatablesExampleWeb.ItemTableView do
       description: item.description,
       price: item.price,
       ui: item.ui,
-      aac: item.aac
+      aac: item.aac,
+      unit: %{
+        description: item.unit.description
+      },
+      category: %{
+        name: item.category.name
+      }
     }
   end
 

--- a/example/lib/phoenix_datatables_example_web/views/item_table_view.ex
+++ b/example/lib/phoenix_datatables_example_web/views/item_table_view.ex
@@ -14,12 +14,8 @@ defmodule PhoenixDatatablesExampleWeb.ItemTableView do
       price: item.price,
       ui: item.ui,
       aac: item.aac,
-      unit: %{
-        description: item.unit.description
-      },
-      category: %{
-        name: item.category.name
-      }
+      unit_description: item.unit.description,
+      category_name: item.category.name,
     }
   end
 

--- a/example/test/phoenix_datatables/query_test.exs
+++ b/example/test/phoenix_datatables/query_test.exs
@@ -79,6 +79,25 @@ defmodule PhoenixDatatables.QueryTest do
 
     end
 
+    test "appends order-by clause to a joined table with name attribute" do
+      [item1, item2] = add_items()
+
+      request = %{Factory.raw_request | "order" => %{"0" => %{"column" => "7", "dir" => "asc"}}}
+      request = put_in(request, ["columns", "7", "data"], "category_name")
+      request = put_in(request, ["columns", "7", "name"], "category.name")
+      query =
+      (from item in Item,
+        join: category in assoc(item, :category),
+        select: %{id: item.id, category_name: category.name})
+
+      params = request |> Request.receive
+      query = Query.sort(query, params)
+
+      [ritem2, ritem1] = query |> Repo.all
+      assert item1.id == ritem1.id
+      assert item2.id == ritem2.id
+    end
+
     test "appends multiple order-by clause to a table" do
       orderings = %{"0" => %{"column" => "1", "dir" => "asc"},
                     "1" => %{"column" => "2", "dir" => "asc"}}

--- a/example/test/phoenix_datatables/request_test.exs
+++ b/example/test/phoenix_datatables/request_test.exs
@@ -32,14 +32,14 @@ defmodule PhoenixDatatables.RequestTest do
         search: %Request.Search{regex: "false", value: ""},
         order: [%Request.Order{column: "0", dir: "asc"}],
         columns: %{
-          "0" => %Request.Column{data: "0", name: "", orderable: true, search: %Request.Search{regex: "false", value: ""}, searchable: true},
-          "1" => %Request.Column{data: "1", name: "", orderable: true, search: %Request.Search{regex: "false", value: ""}, searchable: true},
-          "2" => %Request.Column{data: "2", name: "", orderable: true, search: %Request.Search{regex: "false", value: ""}, searchable: true},
-          "3" => %Request.Column{data: "3", name: "", orderable: true, search: %Request.Search{regex: "false", value: ""}, searchable: true},
-          "4" => %Request.Column{data: "4", name: "", orderable: true, search: %Request.Search{regex: "false", value: ""}, searchable: true},
-          "5" => %Request.Column{data: "5", name: "", orderable: true, search: %Request.Search{regex: "false", value: ""}, searchable: true},
-          "6" => %Request.Column{data: "6", name: "", orderable: true, search: %Request.Search{regex: "false", value: ""}, searchable: true},
-          "7" => %Request.Column{data: "7", name: "", orderable: true, search: %Request.Search{regex: "false", value: ""}, searchable: true}
+          "0" => %Request.Column{data: "0", orderable: true, search: %Request.Search{regex: "false", value: ""}, searchable: true},
+          "1" => %Request.Column{data: "1", orderable: true, search: %Request.Search{regex: "false", value: ""}, searchable: true},
+          "2" => %Request.Column{data: "2", orderable: true, search: %Request.Search{regex: "false", value: ""}, searchable: true},
+          "3" => %Request.Column{data: "3", orderable: true, search: %Request.Search{regex: "false", value: ""}, searchable: true},
+          "4" => %Request.Column{data: "4", orderable: true, search: %Request.Search{regex: "false", value: ""}, searchable: true},
+          "5" => %Request.Column{data: "5", orderable: true, search: %Request.Search{regex: "false", value: ""}, searchable: true},
+          "6" => %Request.Column{data: "6", orderable: true, search: %Request.Search{regex: "false", value: ""}, searchable: true},
+          "7" => %Request.Column{data: "7", orderable: true, search: %Request.Search{regex: "false", value: ""}, searchable: true}
         }
       } = Request.receive(received_params)
     end

--- a/example/test/phoenix_datatables_example_web/controllers/item_table_controller_test.exs
+++ b/example/test/phoenix_datatables_example_web/controllers/item_table_controller_test.exs
@@ -2,14 +2,28 @@ defmodule PhoenixDatatablesExampleWeb.ItemTableControllerTest do
   use PhoenixDatatablesExampleWeb.ConnCase
   alias PhoenixDatatablesExample.Factory
   alias PhoenixDatatablesExample.Stock
+  alias PhoenixDatatablesExample.Repo
+  alias Ecto.Adapters.SQL
 
   setup %{conn: conn} do
+    Seeds.Load.units()
+    Stock.create_item(Factory.item)
+    SQL.query!(Repo, """
+    insert into categories (name) (select distinct rep_office from items);
+    """)
+
+    SQL.query!(Repo, """
+    update items set category_id=(select id from categories where name=items.rep_office);
+    """)
+
+    SQL.query!(Repo, """
+    update items set unit_id=(select id from units where ui_code=items.ui);
+    """)
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 
   describe "index" do
     test "lists all items_tables", %{conn: conn} do
-      Stock.create_item(Factory.item)
       conn = get conn, item_table_path(conn, :index), Factory.raw_request
       assert json_response(conn, 200)["data"] |> List.first |> Map.get("nsn") == "NSN1"
     end

--- a/lib/phoenix_datatables/request.ex
+++ b/lib/phoenix_datatables/request.ex
@@ -31,7 +31,6 @@ defmodule PhoenixDatatables.Request.Column do
   @moduledoc false
   defstruct [
     :data,
-    :name,
     :searchable,
     :orderable,
     :search
@@ -58,9 +57,13 @@ defmodule PhoenixDatatables.Request do
       end
     columns =
       Map.new (for {key, val} <- params["columns"] do
+        data = case val["name"] do
+                "" -> val["data"]
+                name when is_binary(name) -> name
+                _ -> val["data"]
+              end
         {key, %Column{
-          data: val["data"],
-          name: val["name"],
+          data: data,
           searchable: val["searchable"] == "true",
           orderable: val["orderable"] == "true",
           search: %Search{value: val["search"]["value"], regex: val["search"]["regex"]}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PhoenixDatatables.Mixfile do
   def project do
     [
       app: :phoenix_datatables,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env),
       deps: deps(),


### PR DESCRIPTION
This update uses the "name" attribute in the client request to override the qualified column name if it is supplied. Also I've updated the example to use a table with joins, and added an entire `Joins` section to the README.md.