### PR TITLE
Optimize Record Counts

### DIFF
--- a/example/test/phoenix_datatables_test.exs
+++ b/example/test/phoenix_datatables_test.exs
@@ -7,8 +7,8 @@ defmodule PhoenixDatatablesTest do
   alias PhoenixDatatablesExample.Stock.Category
   alias PhoenixDatatablesExample.Factory
 
-  @sortable [:nsn, :common_name]
-  @sortable_join [nsn: 0, common_name: 0, category: [name: 1]]
+  @sortable [columns: [:nsn, :common_name]]
+  @sortable_join [columns: [nsn: 0, common_name: 0, category: [name: 1]]]
 
   describe "execute" do
     test "do all of the things in phoenix datatables" do
@@ -44,6 +44,18 @@ defmodule PhoenixDatatablesTest do
         recordsFiltered: _recordsFiltered,
         recordsTotal: _recordsTotal
       } = PhoenixDatatables.execute(query, request, Repo, @sortable_join)
+      assert draw == request["draw"]
+    end
+
+    test "will override records total with total_entries option" do
+      { request, query } = create_request_and_query()
+      assert %Payload{
+        data: _data,
+        draw: draw,
+        error: _error,
+        recordsFiltered: _recordsFiltered,
+        recordsTotal: 25
+      } = PhoenixDatatables.execute(query, request, Repo, [total_entries: 25])
       assert draw == request["draw"]
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PhoenixDatatables.Mixfile do
   def project do
     [
       app: :phoenix_datatables,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env),
       deps: deps(),


### PR DESCRIPTION
Adds support for `total_entries` option so the application can cache and provide the total entries so that the library doesn't have to run a counts query. Also if the search term is empty, we use the total count (however we got that) instead of running a "filtered" query that would be identical.