### PR TITLE
Add support for sorting NULLS LAST

### DIFF
--- a/example/assets/js/table.js
+++ b/example/assets/js/table.js
@@ -15,6 +15,7 @@ export default function() {
         { data: "price" },
         { data: "unit_description", name: "unit.description" },
         { data: "aac" },
+        { data: "nilable_field" },
       ]
     });
   })

--- a/example/lib/phoenix_datatables_example/stock/item.ex
+++ b/example/lib/phoenix_datatables_example/stock/item.ex
@@ -14,6 +14,7 @@ defmodule PhoenixDatatablesExample.Stock.Item do
     field :price, :float
     field :rep_office, :string
     field :ui, :string
+    field :nilable_field, :string
     belongs_to :category, Category
     belongs_to :unit, Unit
 
@@ -23,7 +24,7 @@ defmodule PhoenixDatatablesExample.Stock.Item do
   @doc false
   def changeset(%Item{} = item, attrs) do
     item
-    |> cast(attrs, [:nsn, :rep_office, :common_name, :description, :price, :ui, :aac, :category_id])
+    |> cast(attrs, [:nsn, :rep_office, :common_name, :description, :price, :ui, :aac, :category_id, :nilable_field])
     |> validate_required([:nsn, :rep_office, :common_name, :description, :price, :ui, :aac])
   end
 end

--- a/example/lib/phoenix_datatables_example/stock/stock.ex
+++ b/example/lib/phoenix_datatables_example/stock/stock.ex
@@ -13,7 +13,7 @@ defmodule PhoenixDatatablesExample.Stock do
       join: category in assoc(item, :category),
       join: unit in assoc(item, :unit),
       preload: [category: category, unit: unit]
-    Repo.fetch_datatable(query, params)
+    Repo.fetch_datatable(query, params, nulls_last: true)
   end
 
   @doc """

--- a/example/lib/phoenix_datatables_example_web/templates/item/form.html.eex
+++ b/example/lib/phoenix_datatables_example_web/templates/item/form.html.eex
@@ -48,6 +48,12 @@
   </div>
 
   <div class="form-group">
+    <%= label f, :nilable_field, class: "control-label" %>
+    <%= text_input f, :nilable_field, class: "form-control" %>
+    <%= error_tag f, :nilable_field %>
+  </div>
+
+  <div class="form-group">
     <%= submit "Submit", class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/example/lib/phoenix_datatables_example_web/templates/item/index.html.eex
+++ b/example/lib/phoenix_datatables_example_web/templates/item/index.html.eex
@@ -10,6 +10,7 @@
       <th>Price</th>
       <th>Ui</th>
       <th>Aac</th>
+      <th>Nilable</th>
     </tr>
   </thead>
 </table>

--- a/example/lib/phoenix_datatables_example_web/templates/item/show.html.eex
+++ b/example/lib/phoenix_datatables_example_web/templates/item/show.html.eex
@@ -37,6 +37,11 @@
     <%= @item.aac %>
   </li>
 
+  <li>
+    <strong>Nilable:</strong>
+    <%= @item.nilable_field %>
+  </li>
+
 </ul>
 
 <span><%= link "Edit", to: Routes.item_path(@conn, :edit, @item) %></span>

--- a/example/lib/phoenix_datatables_example_web/views/item_table_view.ex
+++ b/example/lib/phoenix_datatables_example_web/views/item_table_view.ex
@@ -16,6 +16,7 @@ defmodule PhoenixDatatablesExampleWeb.ItemTableView do
       aac: item.aac,
       unit_description: item.unit.description,
       category_name: item.category.name,
+      nilable_field: item.nilable_field
     }
   end
 

--- a/example/priv/repo/migrations/20190301143837_add_nilable_field.exs
+++ b/example/priv/repo/migrations/20190301143837_add_nilable_field.exs
@@ -1,0 +1,9 @@
+defmodule PhoenixDatatablesExample.Repo.Migrations.AddNilableField do
+  use Ecto.Migration
+
+  def change do
+    alter table(:items) do
+      add :nilable_field, :string
+    end
+  end
+end

--- a/example/test/phoenix_datatables/query_test.exs
+++ b/example/test/phoenix_datatables/query_test.exs
@@ -10,6 +10,7 @@ defmodule PhoenixDatatables.QueryTest do
 
   @sortable [:nsn, :common_name]
   @sortable_join [nsn: 0, category: [name: 1]]
+  @sortable_nulls_last [nulls_last: true]
 
   describe "sort" do
     test "appends order-by clause to a single-table query specifying sortable fields" do
@@ -136,6 +137,31 @@ defmodule PhoenixDatatables.QueryTest do
       assert ritem3.unit_description == "Each"
     end
 
+    test "with nulls last" do
+      original_items = add_items_with_nils()
+      [item1, item2] = original_items
+      assert item1.nilable_field == nil
+      assert item2.nilable_field != nil
+
+      request = %{Factory.raw_request | "order" => %{"0" => %{"column" => "9", "dir" => "desc"}}}
+      query =
+        (from item in Item,
+          select: %{id: item.id, nilable_field: item.nilable_field})
+      params = request |> Request.receive
+      query = Query.sort(query, params)
+      [ritem1, ritem2] = query |> Repo.all
+      assert ritem1.nilable_field == nil
+      assert ritem2.nilable_field != nil
+
+      query =
+        (from item in Item,
+          select: %{id: item.id, nilable_field: item.nilable_field})
+      params = request |> Request.receive
+      query = Query.sort(query, params, @sortable_nulls_last)
+      [ritem1, ritem2] = query |> Repo.all
+      assert ritem1.nilable_field != nil
+      assert ritem2.nilable_field == nil
+    end
   end
 
   describe "paginate" do
@@ -267,6 +293,17 @@ defmodule PhoenixDatatables.QueryTest do
     item = Map.put(Factory.item, :category_id, category_b.id)
     item2 = Map.put(Factory.item, :category_id, category_a.id)
     item2 = %{item2 | nsn: "1NSN"}
+    one = insert_item! item
+    two = insert_item! item2
+    [one, two]
+  end
+
+  def add_items_with_nils do
+    category_a = insert_category!("A")
+    category_b = insert_category!("B")
+    item = Map.put(Factory.item, :category_id, category_a.id)
+    item2 = Map.put(Factory.item, :category_id, category_b.id)
+    item2 = %{item2 | nilable_field: "not nil"}
     one = insert_item! item
     two = insert_item! item2
     [one, two]

--- a/example/test/support/factory.ex
+++ b/example/test/support/factory.ex
@@ -7,7 +7,8 @@ defmodule PhoenixDatatablesExample.Factory do
       description: "you know - pots",
       price: 12.65,
       ui: "EA",
-      aac: "H"
+      aac: "H",
+      nilable_field: nil
     }
   end
 
@@ -24,7 +25,8 @@ defmodule PhoenixDatatablesExample.Factory do
           "5" => %{"data" => "ui", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"},
           "6" => %{"data" => "aac", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"},
           "7" => %{"data" => "category.name", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"},
-          "8" => %{"data" => "unit.description", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"}
+          "8" => %{"data" => "unit.description", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"},
+          "9" => %{"data" => "nilable_field", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"}
         },
       "draw" => "1",
       "length" => "10",

--- a/lib/phoenix_datatables.ex
+++ b/lib/phoenix_datatables.ex
@@ -77,7 +77,7 @@ defmodule PhoenixDatatables do
     total_entries = options[:total_entries] || Query.total_entries(query, repo)
     filtered_query =
       query
-      |> Query.sort(params, options[:columns])
+      |> Query.sort(params, options)
       |> Query.search(params, options)
       |> Query.paginate(params)
 

--- a/lib/phoenix_datatables.ex
+++ b/lib/phoenix_datatables.ex
@@ -67,7 +67,8 @@ defmodule PhoenixDatatables do
       ```
     &nbsp;
 
-  * `:nulls_last` - When `true`, results will be sorted with NULL fields sorted last.
+  * `:nulls_last` - When `true`, results will be sorted with NULL fields sorted last. This option is only
+    valid with PostgreSQL.
   """
   @spec execute(Ecto.Queryable.t,
                 Conn.params,

--- a/lib/phoenix_datatables.ex
+++ b/lib/phoenix_datatables.ex
@@ -67,6 +67,7 @@ defmodule PhoenixDatatables do
       ```
     &nbsp;
 
+  * `:nulls_last` - When `true`, results will be sorted with NULL fields sorted last.
   """
   @spec execute(Ecto.Queryable.t,
                 Conn.params,

--- a/lib/phoenix_datatables/query/macros.ex
+++ b/lib/phoenix_datatables/query/macros.ex
@@ -15,11 +15,14 @@ defmodule PhoenixDatatables.Query.Macros do
   defp def_order_relation(num) do
     bindings = bind_number(num)
     quote do
+      defp nulls_last([nulls_last: nulls_last]), do: nulls_last
+      defp nulls_last(_), do: false
+
       defp order_relation(queryable, unquote(num), dir, column, nil) do
         order_by(queryable, unquote(bindings), [{^dir, field(t, ^column)}])
       end
       defp order_relation(queryable, unquote(num), dir, column, options) when is_list(options) do
-        if Keyword.has_key?(options, :nulls_last) && dir == :desc do
+        if dir == :desc && nulls_last(options) do
           order_by(queryable, unquote(bindings), [fragment("? DESC NULLS LAST", field(t, ^column))])
         else
           order_relation(queryable, unquote(num), dir, column, nil)

--- a/lib/phoenix_datatables/query/macros.ex
+++ b/lib/phoenix_datatables/query/macros.ex
@@ -15,8 +15,15 @@ defmodule PhoenixDatatables.Query.Macros do
   defp def_order_relation(num) do
     bindings = bind_number(num)
     quote do
-      defp order_relation(queryable, unquote(num), dir, column) do
+      defp order_relation(queryable, unquote(num), dir, column, nil) do
         order_by(queryable, unquote(bindings), [{^dir, field(t, ^column)}])
+      end
+      defp order_relation(queryable, unquote(num), dir, column, options) when is_list(options) do
+        if Keyword.has_key?(options, :nulls_last) && dir == :desc do
+          order_by(queryable, unquote(bindings), [fragment("? DESC NULLS LAST", field(t, ^column))])
+        else
+          order_relation(queryable, unquote(num), dir, column, nil)
+        end
       end
     end
   end

--- a/lib/phoenix_datatables/query/macros.ex
+++ b/lib/phoenix_datatables/query/macros.ex
@@ -15,8 +15,13 @@ defmodule PhoenixDatatables.Query.Macros do
   defp def_order_relation(num) do
     bindings = bind_number(num)
     quote do
-      defp nulls_last([nulls_last: nulls_last]), do: nulls_last
-      defp nulls_last(_), do: false
+      defp nulls_last(options) when is_list(options) do
+        if Keyword.has_key?(options, :nulls_last) do
+          options[:nulls_last]
+        else
+          false
+        end
+      end
 
       defp order_relation(queryable, unquote(num), dir, column, nil) do
         order_by(queryable, unquote(bindings), [{^dir, field(t, ^column)}])

--- a/lib/phoenix_datatables/repo.ex
+++ b/lib/phoenix_datatables/repo.ex
@@ -12,8 +12,8 @@ defmodule PhoenixDatatables.Repo do
   """
   defmacro __using__(_) do
     quote do
-      def fetch_datatable(query, params, columns \\ nil) do
-        PhoenixDatatables.execute(query, params, __MODULE__, columns)
+      def fetch_datatable(query, params, options \\ nil) do
+        PhoenixDatatables.execute(query, params, __MODULE__, options)
       end
     end
   end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -11,6 +11,7 @@ defmodule PhoenixDatatables.Fixtures.Stock.Item do
     field :price, :float
     field :rep_office, :string
     field :ui, :string
+    field :nilable_field, :string
     belongs_to :category, Category
     belongs_to :unit, Unit
   end
@@ -51,7 +52,8 @@ defmodule PhoenixDatatables.Fixtures.Factory do
           "5" => %{"data" => "ui", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"},
           "6" => %{"data" => "aac", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"},
           "7" => %{"data" => "category.name", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"},
-          "8" => %{"data" => "unit.description", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"}
+          "8" => %{"data" => "unit.description", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"},
+          "9" => %{"data" => "nilable_field", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"}
         },
       "draw" => "1",
       "length" => "10",
@@ -74,7 +76,8 @@ defmodule PhoenixDatatables.Fixtures.Factory do
           "5" => %{"data" => "ui", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"},
           "6" => %{"data" => "aac", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"},
           "7" => %{"data" => "category", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"},
-          "8" => %{"data" => "unit", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"}
+          "8" => %{"data" => "unit", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"},
+          "9" => %{"data" => "nilable_field", "name" => "", "orderable" => "true", "search" => %{"regex" => "false", "value" => ""}, "searchable" => "true"}
         },
       "draw" => "1",
       "length" => "10",


### PR DESCRIPTION
This adds a `nulls_last` option to `fetch_datatable`. When `nulls_last` is `true` and the sort direction is descending, results will be sorted with NULLs following non-NULL data. This option is only valid with PostgreSQL.

The example site uses `nulls_last: true` as a default now.

There's an existing issue with the example site that allows you to add `Item` records, but doesn't set `category_id` or `unit_id` so they don't display in the table without manual edits. This PR doesn't address that issue.

Re: #20 
