### PR TITLE
Handle order: [] - no sort columns.

### DIFF
--- a/lib/phoenix_datatables/request.ex
+++ b/lib/phoenix_datatables/request.ex
@@ -52,7 +52,7 @@ defmodule PhoenixDatatables.Request do
   """
   def receive(params) do
     orders =
-      for {_key, val} <- params["order"] do
+      for {_key, val} <- params["order"] || [] do
         %Order{column: val["column"], dir: val["dir"]}
       end
     columns =

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PhoenixDatatables.Mixfile do
   def project do
     [
       app: :phoenix_datatables,
-      version: "0.4.1",
+      version: "0.4.2",
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env),
       deps: deps(),


### PR DESCRIPTION
If `order: []` is specified in the client options then no `order` columns are sent, so we should just skip specifying any order by clause instead of exploding.