### PR TITLE
Show correct count when filtering columns

### DIFF
--- a/example/test/phoenix_datatables_test.exs
+++ b/example/test/phoenix_datatables_test.exs
@@ -59,7 +59,7 @@ defmodule PhoenixDatatablesTest do
       assert draw == request["draw"]
     end
 
-    test "do all of the things in phoenix datatables to sort columns" do
+    test "do all of the things in phoenix datatables to search columns" do
       { request, query } = create_request_and_query()
       request = request
       |> update_in(["columns", "0", "search"], &(Map.put(&1, "value", "1NSN")))

--- a/example/test/phoenix_datatables_test.exs
+++ b/example/test/phoenix_datatables_test.exs
@@ -58,6 +58,26 @@ defmodule PhoenixDatatablesTest do
       } = PhoenixDatatables.execute(query, request, Repo, [total_entries: 25])
       assert draw == request["draw"]
     end
+
+    test "do all of the things in phoenix datatables to sort columns" do
+      { request, query } = create_request_and_query()
+      request = request
+      |> update_in(["columns", "0", "search"], &(Map.put(&1, "value", "1NSN")))
+      |> Map.put("search", %{"regex" => "false", "value" => ""})
+
+      assert %Payload{
+        data: data,
+        draw: draw,
+        error: _error,
+        recordsFiltered: recordsFiltered,
+        recordsTotal: recordsTotal
+      } = PhoenixDatatables.execute(query, request, Repo, [columns: [id: 0, common_name: 0, nsn: 0]])
+
+      assert draw == request["draw"]
+      assert Enum.count(data) == 1
+      assert recordsTotal == 2
+      assert recordsFiltered == 1
+    end
   end
 
   def create_request_and_query do
@@ -68,7 +88,7 @@ defmodule PhoenixDatatablesTest do
     query =
       (from item in Item,
         join: category in assoc(item, :category),
-        select: %{id: item.id, category_name: category.name})
+        select: %{id: item.id, category_name: category.name, nsn: item.nsn})
     {request, query}
   end
 

--- a/lib/phoenix_datatables.ex
+++ b/lib/phoenix_datatables.ex
@@ -85,7 +85,7 @@ defmodule PhoenixDatatables do
       |> Query.paginate(params)
 
     filtered_entries =
-      if params.search.value == "" do
+      if params.search.value == "" and not Query.has_column_search?(params.columns) do
         total_entries
       else
         Query.total_entries(filtered_query, repo)

--- a/lib/phoenix_datatables/query.ex
+++ b/lib/phoenix_datatables/query.ex
@@ -254,12 +254,12 @@ defmodule PhoenixDatatables.Query do
     end
   end
 
-  defp has_column_search?(columns) when is_map(columns) do
+  def has_column_search?(columns) when is_map(columns) do
     columns = Map.values(columns)
     Enum.any?(columns, &(&1.search.value != ""))
   end
 
-  defp has_column_search?(_), do: false
+  def has_column_search?(_), do: false
 
   defp do_search_columns(queryable, params, columns) do
     dynamic = dynamic([], true)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PhoenixDatatables.Mixfile do
   def project do
     [
       app: :phoenix_datatables,
-      version: "0.4.3",
+      version: "0.4.4",
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env),
       deps: deps(),


### PR DESCRIPTION
Missed this in the last PR, the count/pagination was always showing the total when filtering columns because there's a condition based on params.search but not the columns.